### PR TITLE
Merge upstream authentication fix

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -4,18 +4,23 @@ Logging into Hangouts using OAuth2 requires a private scope only whitelisted
 for certain clients. This module uses the client ID and secret from iOS, so it
 will appear to Google to be an iOS device. Access can be revoked from this
 page:
-    https://security.google.com/settings/security/permissions
+    https://security.google.com/settings/security/activity
 
-For safety of public debugging, this module should not log any user credentials
-or tokens.
+This module should avoid logging any sensitive login information.
 
-This code may be debugged by invoking it directly:
+This module may be tested by invoking it directly:
     python -m hangups.auth
 """
 
-import requests
+import getpass
 import logging
+import platform
 import urllib.parse
+
+import mechanicalsoup
+import requests
+
+from hangups import version
 
 logger = logging.getLogger(__name__)
 # Set the logging level for requests to at least INFO, since the DEBUG level
@@ -23,113 +28,218 @@ logger = logging.getLogger(__name__)
 if logging.getLogger('requests').isEnabledFor(logging.DEBUG):
     logging.getLogger('requests').setLevel(logging.INFO)
 
-OAUTH2_SCOPE = 'https://www.google.com/accounts/OAuthLogin'
 OAUTH2_CLIENT_ID = '936475272427.apps.googleusercontent.com'
 OAUTH2_CLIENT_SECRET = 'KWsJlkaMn1jGLxQpWxMnOox-'
-OAUTH2_LOGIN_URL = 'https://accounts.google.com/o/oauth2/auth?{}'.format(
-    urllib.parse.urlencode(dict(
-        client_id=OAUTH2_CLIENT_ID,
-        scope=OAUTH2_SCOPE,
-        redirect_uri='urn:ietf:wg:oauth:2.0:oob',
-        response_type='code',
-    ))
+OAUTH2_SCOPES = [
+    'https://www.google.com/accounts/OAuthLogin',
+    'https://www.googleapis.com/auth/userinfo.email',
+]
+# Note that '+' separating scopes must not be escaped by urlencode
+OAUTH2_LOGIN_URL = (
+    'https://accounts.google.com/o/oauth2/programmatic_auth?{}'.format(
+        urllib.parse.urlencode(dict(
+            scope='+'.join(OAUTH2_SCOPES),
+            client_id=OAUTH2_CLIENT_ID,
+        ), safe='+')
+    )
 )
 OAUTH2_TOKEN_REQUEST_URL = 'https://accounts.google.com/o/oauth2/token'
+FORM_SELECTOR = '#gaia_loginform'
+EMAIL_SELECTOR = '#Email'
+PASSWORD_SELECTOR = '#Passwd'
+VERIFICATION_FORM_SELECTOR = '#challenge'
+VERIFICATION_CODE_SELECTOR = '#totpPin'
+USER_AGENT = 'hangups/{} ({} {})'.format(
+    version.__version__, platform.system(), platform.machine()
+)
 
 
 class GoogleAuthError(Exception):
-
     """Exception raised when auth fails."""
 
 
-def _load_oauth2_refresh_token(refresh_token_filename):
-    """Return refresh_token loaded from file or None on failure."""
-    logger.info('Loading refresh_token from \'%s\'', refresh_token_filename)
-    try:
-        with open(refresh_token_filename) as f:
-            return f.read()
-    except IOError as e:
-        logger.info('Failed to load refresh_token: %s', e)
+def get_auth_stdin(refresh_token_filename):
+    """Wrapper for get_auth that prompts the user on stdin."""
+    refresh_token_cache = RefreshTokenCache(refresh_token_filename)
+    return get_auth(CredentialsPrompt(), refresh_token_cache)
 
 
-def _save_oauth2_refresh_token(refresh_token_filename, refresh_token):
-    """Save refresh_token to file, ignoring failure."""
-    logger.info('Saving refresh_token to \'%s\'', refresh_token_filename)
-    try:
-        with open(refresh_token_filename, 'w') as f:
-            f.write(refresh_token)
-    except IOError as e:
-        logger.warning('Failed to save refresh_token: %s', e)
-    return refresh_token
+class CredentialsPrompt(object):
+    """Callbacks for prompting user for their Google account credentials."""
+
+    @staticmethod
+    def get_email():
+        """Return Google account email address."""
+        print('Sign in with your Google account:')
+        return input('Email: ')
+
+    @staticmethod
+    def get_password():
+        """Return Google account password."""
+        return getpass.getpass()
+
+    @staticmethod
+    def get_verification_code():
+        """Return Google account verification code."""
+        return input('Verification code: ')
 
 
-def get_auth(get_code_f, refresh_token_filename):
-    """Login into Google and return cookies as a dict.
+class RefreshTokenCache(object):
+    """File-based cache for refresh token."""
 
-    get_code_f() is called if authorization code is required to log in, and
-    should return the code as a string.
+    def __init__(self, filename):
+        self._filename = filename
 
-    A refresh token is saved/loaded from refresh_token_filename if possible, so
+    def get(self):
+        """Return cached refresh_token loaded or None on failure."""
+        logger.info(
+            'Loading refresh_token from %s', repr(self._filename)
+        )
+        try:
+            with open(self._filename) as f:
+                return f.read()
+        except IOError as e:
+            logger.info('Failed to load refresh_token: %s', e)
+
+    def set(self, refresh_token):
+        """Cache refresh_token string, ignoring any failure."""
+        logger.info('Saving refresh_token to %s', repr(self._filename))
+        try:
+            with open(self._filename, 'w') as f:
+                f.write(refresh_token)
+        except IOError as e:
+            logger.warning('Failed to save refresh_token: %s', e)
+        return refresh_token
+
+
+def get_auth(credentials_prompt, refresh_token_cache):
+    """Authenticate into Google and return session cookies as a dict.
+
+    credentials_prompt is used if credentials are required to log in.
+
+    A refresh token is saved/loaded from refresh_token_cache if possible, so
     subsequent logins may not require re-authenticating.
 
     Raises GoogleAuthError on failure.
     """
+    session = requests.Session()
+    session.headers = {'user-agent': USER_AGENT}
+
     try:
         logger.info('Authenticating with refresh token')
-        access_token = _auth_with_refresh_token(refresh_token_filename)
+        refresh_token = refresh_token_cache.get()
+        if refresh_token is None:
+            raise GoogleAuthError("Refresh token not found")
+        access_token = _auth_with_refresh_token(session, refresh_token)
     except GoogleAuthError as e:
         logger.info('Failed to authenticate using refresh token: %s', e)
-        logger.info('Authenticating with authorization code')
-        access_token = _auth_with_code(get_code_f, refresh_token_filename)
+        logger.info('Authenticating with credentials')
+        authorization_code = _get_authorization_code(
+            session, credentials_prompt
+        )
+        access_token, refresh_token = _auth_with_code(
+            session, authorization_code
+        )
+        refresh_token_cache.set(refresh_token)
+
     logger.info('Authentication successful')
-    return _get_session_cookies(access_token)
+    return _get_session_cookies(session, access_token)
 
 
-def _auth_with_code(get_code_f, refresh_token_filename):
-    """Authenticate using OAuth authentication code.
+class Browser(object):
+    """Virtual browser for submitting forms and moving between pages.
+
+    Raises GoogleAuthError if URL fails to load.
+    """
+
+    def __init__(self, session, url):
+        self._session = session
+        self._browser = mechanicalsoup.Browser(
+            soup_config=dict(features='html.parser'), session=self._session
+        )
+        try:
+            self._page = self._browser.get(url)
+            self._page.raise_for_status()
+        except requests.RequestException as e:
+            raise GoogleAuthError('Failed to load form: {}'.format(e))
+
+    def has_form(self, form_selector):
+        """Return True if form_selector finds a form on the current page."""
+        return len(self._page.soup.select(form_selector)) > 0
+
+    def submit_form(self, form_selector, input_dict):
+        """Populate and submit a form on the current page.
+
+        Raises GoogleAuthError if form can not be submitted.
+        """
+        try:
+            form = self._page.soup.select(form_selector)[0]
+        except IndexError:
+            raise GoogleAuthError(
+                'Failed to find form {!r} in page'.format(form_selector)
+            )
+        for selector, value in input_dict.items():
+            try:
+                form.select(selector)[0]['value'] = value
+            except IndexError:
+                raise GoogleAuthError(
+                    'Failed to find input {!r} in form'.format(selector)
+                )
+        try:
+            self._page = self._browser.submit(form, self._page.url)
+            self._page.raise_for_status()
+        except requests.RequestException as e:
+            raise GoogleAuthError('Failed to submit form: {}'.format(e))
+
+    def get_cookie(self, name):
+        """Return cookie value from the browser session.
+
+        Raises KeyError if cookie is not found.
+        """
+        return self._session.cookies[name]
+
+
+def _get_authorization_code(session, credentials_prompt):
+    """Get authorization code using Google account credentials.
+
+    Because hangups can't use a real embedded browser, it has to use the
+    Browser class to enter the user's credentials and retrieve the
+    authorization code, which is placed in a cookie. This is the most fragile
+    part of the authentication process, because a change to a login form or an
+    unexpected prompt could break it.
 
     Raises GoogleAuthError authentication fails.
 
-    Return access token string.
+    Returns authorization code string.
     """
-    # Get authentication code from user.
-    auth_code = get_code_f()
+    browser = Browser(session, OAUTH2_LOGIN_URL)
 
-    # Make a token request.
-    token_request_data = {
-        'client_id': OAUTH2_CLIENT_ID,
-        'client_secret': OAUTH2_CLIENT_SECRET,
-        'code': auth_code,
-        'grant_type': 'authorization_code',
-        'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
-    }
-    r = requests.post(OAUTH2_TOKEN_REQUEST_URL, data=token_request_data)
-    res = r.json()
+    email = credentials_prompt.get_email()
+    browser.submit_form(FORM_SELECTOR, {EMAIL_SELECTOR: email})
 
-    # If an error occurred, a key 'error' will contain an error code.
-    if 'error' in res:
-        raise GoogleAuthError('Authorization error: \'{}\''
-                              .format(res['error']))
+    password = credentials_prompt.get_password()
+    browser.submit_form(FORM_SELECTOR, {PASSWORD_SELECTOR: password})
 
-    # Save the refresh token.
-    _save_oauth2_refresh_token(refresh_token_filename, res['refresh_token'])
+    if browser.has_form(VERIFICATION_FORM_SELECTOR):
+        verfification_code = credentials_prompt.get_verification_code()
+        browser.submit_form(
+            VERIFICATION_FORM_SELECTOR,
+            {VERIFICATION_CODE_SELECTOR: verfification_code}
+        )
 
-    return res['access_token']
+    try:
+        return browser.get_cookie('oauth_code')
+    except KeyError:
+        raise GoogleAuthError('Authorization code cookie not found')
 
 
-def _auth_with_refresh_token(refresh_token_filename):
-    """Authenticate using saved OAuth refresh token.
+def _auth_with_refresh_token(session, refresh_token):
+    """Authenticate using OAuth refresh token.
 
-    Raises GoogleAuthError if refresh token is not found or authentication
-    fails.
+    Raises GoogleAuthError if authentication fails.
 
-    Return access token string.
+    Returns access token string.
     """
-    # Load saved refresh token if present.
-    refresh_token = _load_oauth2_refresh_token(refresh_token_filename)
-    if refresh_token is None:
-        raise GoogleAuthError("Refresh token not found")
-
     # Make a token request.
     token_request_data = {
         'client_id': OAUTH2_CLIENT_ID,
@@ -137,45 +247,83 @@ def _auth_with_refresh_token(refresh_token_filename):
         'grant_type': 'refresh_token',
         'refresh_token': refresh_token,
     }
-    r = requests.post(OAUTH2_TOKEN_REQUEST_URL, data=token_request_data)
-    res = r.json()
-
-    # If an error occurred, a key 'error' will contain an error code.
-    if 'error' in res:
-        raise GoogleAuthError('Authorization error: \'{}\''
-                              .format(res['error']))
-
+    res = _make_token_request(session, token_request_data)
     return res['access_token']
 
 
-def _get_session_cookies(access_token):
+def _auth_with_code(session, authorization_code):
+    """Authenticate using OAuth authorization code.
+
+    Raises GoogleAuthError if authentication fails.
+
+    Returns access token string and refresh token string.
+    """
+    # Make a token request.
+    token_request_data = {
+        'client_id': OAUTH2_CLIENT_ID,
+        'client_secret': OAUTH2_CLIENT_SECRET,
+        'code': authorization_code,
+        'grant_type': 'authorization_code',
+        'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+    }
+    res = _make_token_request(session, token_request_data)
+    return res['access_token'], res['refresh_token']
+
+
+def _make_token_request(session, token_request_data):
+    """Make OAuth token request.
+
+    Raises GoogleAuthError if authentication fails.
+
+    Returns dict response.
+    """
+    try:
+        r = session.post(OAUTH2_TOKEN_REQUEST_URL, data=token_request_data)
+        r.raise_for_status()
+    except requests.RequestException as e:
+        raise GoogleAuthError('Token request failed: {}'.format(e))
+    else:
+        res = r.json()
+        # If an error occurred, a key 'error' will contain an error code.
+        if 'error' in res:
+            raise GoogleAuthError(
+                'Token request error: {!r}'.format(res['error'])
+            )
+        return res
+
+
+def _get_session_cookies(session, access_token):
     """Use the access token to get session cookies.
 
-    Return dict of cookies.
+    Raises GoogleAuthError if session cookies could not be loaded.
+
+    Returns dict of cookies.
     """
-    session = requests.Session()
     headers = {'Authorization': 'Bearer {}'.format(access_token)}
-    r = session.get(('https://accounts.google.com/accounts/OAuthLogin'
-                     '?source=hangups&issueuberauth=1'), headers=headers)
+
+    try:
+        r = session.get(('https://accounts.google.com/accounts/OAuthLogin'
+                         '?source=hangups&issueuberauth=1'), headers=headers)
+        r.raise_for_status()
+    except requests.RequestException as e:
+        raise GoogleAuthError('OAuthLogin request failed: {}'.format(e))
     uberauth = r.text
-    r = session.get(('https://accounts.google.com/MergeSession?'
-                     'service=mail&continue=http://www.google.com&uberauth={}')
-                    .format(uberauth), headers=headers)
-    return session.cookies.get_dict(domain='.google.com')
 
+    try:
+        r = session.get(('https://accounts.google.com/MergeSession?'
+                         'service=mail&'
+                         'continue=http://www.google.com&uberauth={}')
+                        .format(uberauth), headers=headers)
+        r.raise_for_status()
+    except requests.RequestException as e:
+        raise GoogleAuthError('MergeSession request failed: {}'.format(e))
 
-def get_auth_stdin(refresh_token_filename):
-    """Wrapper for get_auth that prompts the user on stdin."""
-    def get_code_f():
-        """Prompt for and return credentials."""
-        print('To log in, open the following link in a browser and paste the '
-              'provided authorization code below:\n')
-        print(OAUTH2_LOGIN_URL)
-        auth_token = input('\nAuthorization Token: ')
-        return auth_token
-    return get_auth(get_code_f, refresh_token_filename)
+    cookies = session.cookies.get_dict(domain='.google.com')
+    if cookies == {}:
+        raise GoogleAuthError('Failed to find session cookies')
+    return cookies
 
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    print(get_auth_stdin('oauth2.json'))
+    print(get_auth_stdin('refresh_token.txt'))

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     'hangups-urwid==1.2.2-dev',
     # backport asyncio for python3.3:
     'asyncio==3.4.3',
+    'MechanicalSoup==0.4.0',
 ]
 
 if sys.version_info < (3, 4):
@@ -64,6 +65,7 @@ setup(
     install_requires=install_requires,
     tests_require=[
         'pytest',
+        'httpretty==0.8.14',
     ],
     cmdclass={'test': PyTest},
     entry_points={


### PR DESCRIPTION
Merge authentication fix 1f31a927fca550a7424439f52b3e6f70a5a228ba by tdryer from upstream hangups repository

Google recently broke the previous login method, which involved logging
in using a browser and copying an authorization code to hangups. This
change implements a new login method to emulate a browser submitting
login credentials, providing access to the authorization code via a
cookie.

See https://github.com/tdryer/hangups/issues/260.