### PR TITLE
Fix attachments being thrown away when parsing payloads

### DIFF
--- a/hangups/conversation_event.py
+++ b/hangups/conversation_event.py
@@ -161,8 +161,13 @@ class ChatMessageEvent(ConversationEvent):
                 # message segments, and thus have no automatic textual
                 # fallback.
                 try:
+                    if attachment.embed_item.data is not None:
+                        data = attachment.embed_item.data['27639957']
+                    else:
+                        # iOS f***ing around with byte stream field order
+                        data = attachment.embed_item.data_['27639957']
                     attachments.append(
-                        attachment.embed_item.data['27639957'][0][3]
+                        data[0][3]
                     )
                 except (KeyError, TypeError, IndexError):
                     logger.warning(

--- a/hangups/schemas.py
+++ b/hangups/schemas.py
@@ -244,7 +244,8 @@ MESSAGE_ATTACHMENT = Message(
     ('embed_item', Message(
         # 249 (PLUS_PHOTO), 340, 335, 0
         ('type_', RepeatedField(Field())),
-        ('data', Field()),  # can be a dict
+        ('name', Field()),
+        ('data', Field(is_optional=True)),  # can be a dict
     )),
 )
 

--- a/hangups/schemas.py
+++ b/hangups/schemas.py
@@ -244,7 +244,7 @@ MESSAGE_ATTACHMENT = Message(
     ('embed_item', Message(
         # 249 (PLUS_PHOTO), 340, 335, 0
         ('type_', RepeatedField(Field())),
-        ('name', Field()),
+        ('data_', Field()),
         ('data', Field(is_optional=True)),  # can be a dict
     )),
 )


### PR DESCRIPTION
The protocol seems to have changed and an additional field was inserted which resulted in attachments being thrown away. Because of this, no images could be synced from Hangouts to Telegram using the telesync plugin. This pull requests adjusts the message schema to reflect the current protocol.