### PR TITLE
Update client.py to sort connection issues in current master(v2.8)

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -27,7 +27,8 @@ CHAT_INIT_PARAMS = {
     'pvt': None,  # Populated later
 }
 CHAT_INIT_REGEX = re.compile(
-    r"(?:<script>AF_initDataCallback\((.*?)\);</script>)", re.DOTALL
+    #r"(?:<script>AF_initDataCallback\((.*?)\);</script>)", re.DOTALL
+    r"(?:<script nonce=\"[a-zA-Z0-9_+/]*\">AF_initDataCallback\((.*?)\);</script>)", re.DOTALL
 )
 # Timeout to send for setactiveclient requests:
 ACTIVE_TIMEOUT_SECS = 120


### PR DESCRIPTION
This sorts out issue number #925 "5/16/18 key error ds:7"
The current master(v2.8) relies on this branch of the hangups api(which is quite old). This edit fixes the recent connection issues.
The response returned had some extra parameters for which the regex was edited to get the relevant fields.