### PR TITLE
Add the nonce in the regex of init response

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -27,7 +27,7 @@ CHAT_INIT_PARAMS = {
     'pvt': None,  # Populated later
 }
 CHAT_INIT_REGEX = re.compile(
-    r"(?:<script>AF_initDataCallback\((.*?)\);</script>)", re.DOTALL
+    r"(?:<script nonce=\".*?\">AF_initDataCallback\((.*?)\);</script>)", re.DOTALL
 )
 # Timeout to send for setactiveclient requests:
 ACTIVE_TIMEOUT_SECS = 120


### PR DESCRIPTION
I was having issues with hangups connecting.  I found that the response from google had added a nonce and that was messing up the parsing of the returned json.  We might want to do something with the nonce but for now this PR ignores it.  If other people aren't seeing this issue this PR should be reject.